### PR TITLE
Updated class methods

### DIFF
--- a/src/sciscrape/downloaders.py
+++ b/src/sciscrape/downloaders.py
@@ -42,7 +42,7 @@ class DownloadReceipt:
 
     @classmethod
     def from_dict(cls, dict_input: dict):
-        return DownloadReceipt(**dict_input)
+        return cls(**dict_input)
 
     def to_dict(self):
         return asdict(self)

--- a/src/sciscrape/fetch.py
+++ b/src/sciscrape/fetch.py
@@ -203,8 +203,8 @@ class SciScraper:
         """Removes all empty columns in the dataframe before exporting to .csv."""
         return dataframe.replace("", float("NaN")).dropna(how="all", axis=1)
 
-    @classmethod
-    def dataframe_casting(cls, dataframe: pd.DataFrame) -> pd.DataFrame:
+    @staticmethod
+    def dataframe_casting(dataframe: pd.DataFrame) -> pd.DataFrame:
         """
         Formats and optimizes the final dataframe through converting datatypes
         and filling missing fields, where possible.
@@ -217,7 +217,7 @@ class SciScraper:
 
         # Convert "pub_date" column to datetime data type
         if "pub_date" in dataframe:
-            dataframe["pub_date"] = cls.downcast_available_datetimes(dataframe)
+            dataframe["pub_date"] = SciScraper.downcast_available_datetimes(dataframe)
 
         # Convert columns in KEY_TYPE_PAIRINGS dictionary to specified data types
         for scikey, value in KEY_TYPE_PAIRINGS.items():
@@ -225,30 +225,30 @@ class SciScraper:
                 dataframe[scikey] = dataframe[scikey].astype(value)
         return dataframe
 
-    @classmethod
-    def downcast_available_datetimes(cls, dataframe: pd.DataFrame | pd.Series):
+    @staticmethod
+    def downcast_available_datetimes(dataframe: pd.DataFrame | pd.Series):
         """Converts all paper publication dates to the datetime format."""
         return pd.to_datetime(dataframe["pub_date"], infer_datetime_format=True)
 
-    @classmethod
+    @staticmethod
     def export(
-        cls, dataframe: pd.DataFrame, export_dir: str = config.export_dir
+        dataframe: pd.DataFrame, export_dir: str = config.export_dir
     ) -> None:
         """Export data to the specified export directory."""
-        cls.dataframe_logging(dataframe)
-        export_name = cls.create_export_name()
+        SciScraper.dataframe_logging(dataframe)
+        export_name = SciScraper.create_export_name()
         with change_dir(export_dir):
             logger.info(f"A spreadsheet was exported as {export_name} in {export_dir}.")
             dataframe.to_csv(export_name, index=False)
 
-    @classmethod
-    def dataframe_logging(cls, dataframe: pd.DataFrame) -> None:
+    @staticmethod
+    def dataframe_logging(dataframe: pd.DataFrame) -> None:
         """Returns the first ten rows of the dataframe into the logger."""
         dataframe.info(verbose=True)
         logger.info(f"\n\n{dataframe.head(10)}")
 
-    @classmethod
-    def create_export_name(cls) -> str:
+    @staticmethod
+    def create_export_name() -> str:
         """Returns a `export_name` for the spreadsheet with
         both today's date and a randomly generated `print_id`
         number."""

--- a/src/sciscrape/webscrapers.py
+++ b/src/sciscrape/webscrapers.py
@@ -46,7 +46,7 @@ class WebScrapeResult:
 
     @classmethod
     def from_dict(cls, dict_input: dict):
-        return WebScrapeResult(**dict_input)
+        return cls(**dict_input)
 
     def to_dict(self):
         return asdict(self)

--- a/src/sciscrape/wordscore.py
+++ b/src/sciscrape/wordscore.py
@@ -13,7 +13,7 @@ class Wordscore:
 
     @classmethod
     def from_dict(cls, dict_input: dict):
-        return Wordscore(**dict_input)
+        return cls(**dict_input)
 
     def to_dict(self):
         return asdict(self)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -142,19 +142,19 @@ class TestClass:
     def set_logging(self, debug: bool) -> None:
         logger.setLevel(10) if debug else logger.setLevel(20)
 
-    @classmethod
-    def dataframe_logging(cls, dataframe: pd.DataFrame) -> None:
+    @staticmethod
+    def dataframe_logging(dataframe: pd.DataFrame) -> None:
         pass
 
-    @classmethod
-    def create_export_name(cls) -> str:
+    @staticmethod
+    def create_export_name() -> str:
         return "test_50.csv"
 
-    @classmethod
-    def export(cls, dataframe: pd.DataFrame, export_dir: str = "export") -> None:
+    @staticmethod
+    def export(dataframe: pd.DataFrame, export_dir: str = "export") -> None:
         """Export data to the specified export directory."""
-        cls.dataframe_logging(dataframe)
-        export_name = cls.create_export_name()
+        TestClass.dataframe_logging(dataframe)
+        export_name = TestClass.create_export_name()
         with change_dir(export_dir):
             logger.info(f"A spreadsheet was exported as {export_name}.")
             dataframe.to_csv(export_name)


### PR DESCRIPTION
Improved existing class methods to actually use the `cls` parameter instead of the class name. I also changed some class methods to static methods, mainly those that don't use the `cls` parameter at all or where it makes more sense for it to be static instead (e.g. returning something different than a class instance). For some static methods, I explicitly used the class name assuming it's never subclassed, but that change was pretty subjective so I can revert it if needed.