### PR TITLE
Greatly improved typehints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,10 +4,8 @@ By John Fallot <john.fallot@gmail.com>
 """
 from __future__ import annotations
 
-from argparse import Namespace
 from typing import Sequence
 from time import perf_counter
-from sciscrape.fetch import SciScraper
 
 from sciscrape.log import logger
 from sciscrape.profilers import get_profiler
@@ -35,10 +33,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     None
     """
 
-    args: Namespace = build_args(argv)
+    args = build_args(argv)
 
     start = perf_counter()
-    sciscrape: SciScraper = (
+    sciscrape = (
         read_factory() if args.mode is None else SCISCRAPERS[args.mode]
     )
     logger.debug(repr(sciscrape))

--- a/src/main.py
+++ b/src/main.py
@@ -2,9 +2,10 @@
 
 By John Fallot <john.fallot@gmail.com>
 """
+from __future__ import annotations
 
 from argparse import Namespace
-from typing import Optional, Sequence
+from typing import Sequence
 from time import perf_counter
 from sciscrape.fetch import SciScraper
 
@@ -14,7 +15,7 @@ from sciscrape.factories import read_factory, SCISCRAPERS
 from sciscrape.argsbuilder import build_args
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """
     Entry point for the `sciscraper` application. Parses command line arguments and executes the appropriate actions.
 

--- a/src/sciscrape/argsbuilder.py
+++ b/src/sciscrape/argsbuilder.py
@@ -2,12 +2,14 @@ r"""argsbuilder constructs the argparser for sciscraper,
 for use in the `main` module.
 """
 
+from __future__ import annotations
+
 import argparse
-from typing import Optional, Sequence
+from typing import Sequence
 from sciscrape.config import config
 
 
-def build_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+def build_args(argv: Sequence[str] | None) -> argparse.Namespace:
     """
     build_args builds the argument parser for sciscraper.
 

--- a/src/sciscrape/change_dir.py
+++ b/src/sciscrape/change_dir.py
@@ -4,12 +4,12 @@ processes for the sciscraper program.
 """
 from contextlib import contextmanager
 from os import chdir, getcwd, makedirs, path
-from typing import Generator
+from typing import Iterator
 from sciscrape.config import FilePath
 
 
 @contextmanager
-def change_dir(destination: FilePath) -> Generator[None, None, None]:
+def change_dir(destination: FilePath) -> Iterator[None]:
     """Sets a destination for exported files."""
     cwd = getcwd()
     try:

--- a/src/sciscrape/change_dir.py
+++ b/src/sciscrape/change_dir.py
@@ -11,9 +11,9 @@ from sciscrape.config import FilePath
 @contextmanager
 def change_dir(destination: FilePath) -> Generator[None, None, None]:
     """Sets a destination for exported files."""
-    cwd: str = getcwd()
+    cwd = getcwd()
     try:
-        dest: str = path.realpath(destination)
+        dest = path.realpath(destination)
         makedirs(dest, exist_ok=True)
         chdir(dest)
         yield

--- a/src/sciscrape/docscraper.py
+++ b/src/sciscrape/docscraper.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from itertools import chain
 import pdfplumber
 import re
 from collections import Counter
 from dataclasses import asdict, dataclass, field
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 from sciscrape.wordscore import WordscoreCalculator
 from sciscrape.log import logger
 from sciscrape.config import UTF, FilePath
@@ -128,7 +130,7 @@ class DocScraper:
             logger.debug("func=%s, word_set=%s", self.unpack_txt_files, wordset)
             return wordset
 
-    def obtain(self, search_text: str) -> Optional[DocumentResult]:
+    def obtain(self, search_text: str) -> DocumentResult | None:
         """
         Given the provided search string, it extracts the text from
         the pdf or abstract provided, it cleans the text in question,

--- a/src/sciscrape/docscraper.py
+++ b/src/sciscrape/docscraper.py
@@ -85,11 +85,11 @@ def match_terms(target: list[str], word_set: set[str]) -> FreqDistAndCount:
     >>> output.term_count           = 7
     """
 
-    matching_terms: list[tuple[str, int]] = Counter(
+    matching_terms = Counter(
         (word for word in target if word in word_set)
     ).most_common(3)
-    term_count: int = sum(term[1] for term in matching_terms)
-    freq: FreqDistAndCount = FreqDistAndCount(term_count, matching_terms)
+    term_count = sum(term[1] for term in matching_terms)
+    freq = FreqDistAndCount(term_count, matching_terms)
     logger.debug(
         "match_terms=%r,\
         frequent_terms=%s",
@@ -125,8 +125,8 @@ class DocScraper:
             set[str]: A set of words against which the text will be compared.
         """
         with open(txtfile, encoding=UTF) as iowrapper:
-            textlines: list[str] = iowrapper.readlines()
-            wordset: set[str] = {word.strip().lower() for word in textlines}
+            textlines = iowrapper.readlines()
+            wordset = {word.strip().lower() for word in textlines}
             logger.debug("func=%s, word_set=%s", self.unpack_txt_files, wordset)
             return wordset
 
@@ -157,8 +157,8 @@ class DocScraper:
             else self.extract_text_from_summary(search_text)
         )
         token_list = next(token_generator)
-        target: FreqDistAndCount = match_terms(token_list, target_set)
-        bycatch: FreqDistAndCount = match_terms(token_list, bycatch_set)
+        target = match_terms(token_list, target_set)
+        bycatch = match_terms(token_list, bycatch_set)
         wordcalc = WordscoreCalculator(
             target.term_count,
             bycatch.term_count,
@@ -201,8 +201,8 @@ class DocScraper:
         """
         with pdfplumber.open(search_text) as study:
             study_pages: list[Any] = study.pages
-            study_length: int = len(study_pages)
-            pages_to_check: list[Any] = [*study_pages][:study_length]
+            study_length = len(study_pages)
+            pages_to_check = [*study_pages][:study_length]
             logger.debug(
                 "func=%s,\
                 study_length=%s,\
@@ -263,8 +263,8 @@ class DocScraper:
             self.extract_text_from_summary,
             search_text,
         )
-        manuscript: str = search_text.strip().lower()
-        output: list[str] = manuscript.split(" ")
+        manuscript = search_text.strip().lower()
+        output = manuscript.split(" ")
         logger.debug(
             "func=%s,\
             output=%s",

--- a/src/sciscrape/docscraper.py
+++ b/src/sciscrape/docscraper.py
@@ -30,10 +30,10 @@ class FreqDistAndCount:
     frequency_dist: list[tuple[str, int]] = field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, dict_input: dict):
+    def from_dict(cls, dict_input: dict[str, Any]) -> FreqDistAndCount:
         return cls(**dict_input)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 

--- a/src/sciscrape/docscraper.py
+++ b/src/sciscrape/docscraper.py
@@ -5,7 +5,7 @@ import pdfplumber
 import re
 from collections import Counter
 from dataclasses import asdict, dataclass, field
-from typing import Any, Generator
+from typing import Any, Iterator
 from sciscrape.wordscore import WordscoreCalculator
 from sciscrape.log import logger
 from sciscrape.config import UTF, FilePath
@@ -151,7 +151,7 @@ class DocScraper:
         target_set = self.unpack_txt_files(self.target_words_file)
         bycatch_set = self.unpack_txt_files(self.bycatch_words_file)
 
-        token_generator: Generator[list[str], None, None] = (
+        token_generator: Iterator[list[str]] = (
             self.extract_text_from_pdf(search_text)
             if self.is_pdf
             else self.extract_text_from_summary(search_text)
@@ -184,7 +184,7 @@ class DocScraper:
 
     def extract_text_from_pdf(
         self, search_text: str
-    ) -> Generator[list[str], None, None]:
+    ) -> Iterator[list[str]]:
         """
         Given the provided filepath, `search_text`, it opens the .pdf
         file and cleans the text. Returning the words from each page
@@ -212,13 +212,13 @@ class DocScraper:
                 search_text,
             )
             # Goes through all pages and creates a continuous string of text from the entire document
-            preprints: Generator[str, None, None] = (
+            preprints: Iterator[str] = (
                 study_pages[page_number].extract_text(x_tolerance=1, y_tolerance=3)
                 for page_number, _ in enumerate(pages_to_check)
             )
 
             # Strips and lowers every word
-            manuscripts: Generator[Any, None, None] = (
+            manuscripts: Iterator[str] = (
                 preprint.strip().lower() for preprint in preprints
             )
 
@@ -228,7 +228,7 @@ class DocScraper:
             )
 
             # Splits each word along each white space to create a list of strings from each word
-            output: Generator[list[str], None, None] = (
+            output: Iterator[list[str]] = (
                 manuscript.split(" ") for manuscript in manuscripts
             )
             logger.debug(
@@ -242,7 +242,7 @@ class DocScraper:
 
     def extract_text_from_summary(
         self, search_text: str
-    ) -> Generator[list[str], None, None]:
+    ) -> Iterator[list[str]]:
         """
         Given the provided abstract, `search_text`, it reads the text
         and cleans it. Returning the words from each

--- a/src/sciscrape/downloaders.py
+++ b/src/sciscrape/downloaders.py
@@ -170,7 +170,7 @@ class BulkPDFScraper(Downloader):
         """
         payload: dict[str, str] = {"request": search_text}
         paper_title: str = f'{config.today}_{search_text.replace("/","")}.pdf'
-        response_text: Optional[str] = self.get_response(payload)
+        response_text = self.get_response(payload)
 
         download_link: str | None = (
             None if response_text is None else self.find_download_link(response_text)
@@ -219,7 +219,7 @@ class BulkPDFScraper(Downloader):
         str
             A download link, which will download a link to the paper.
         """
-        html: HTMLParser = HTMLParser(search_text)
+        html = HTMLParser(search_text)
         try:
             download_link: str | None = html.css_first(
                 "#buttons button:nth-child(1)"
@@ -295,7 +295,7 @@ class ImagesDownloader(Downloader):
     def obtain(self, search_text: str) -> DownloadReceipt | None:
         sleep(self.sleep_val)
         search_ext = search_text.split(".")[-1]
-        response: Response = client.get(search_text, stream=True, allow_redirects=True)
+        response = client.get(search_text, stream=True, allow_redirects=True)
         logger.debug(
             "response=%r, scraper=%r, status_code=%s",
             response,
@@ -325,9 +325,9 @@ class ImagesDownloader(Downloader):
         DownloadReceipt:
             A receipt indicating whether the image was successfully downloaded and the path to the downloaded image.
         """
-        filename: str = self.format_filename(response.headers.get("Etag"), search_ext)
+        filename = self.format_filename(response.headers.get("Etag"), search_ext)
         self.create_document(filename, response.content)
-        fullpath: str = str(path.abspath(filename))
+        fullpath = str(path.abspath(filename))
         return DownloadReceipt(self.cls_name, True, fullpath)
 
     def format_filename(self, etag: str | None, ext: str) -> str:
@@ -346,10 +346,10 @@ class ImagesDownloader(Downloader):
             A filename to which the image will be downloaded.
         """
 
-        file_id: int = random.randint(1, 255)
+        file_id = random.randint(1, 255)
         if etag:
             etag = etag.strip('"')
-            filename: str = f"{config.today}_{etag}_{file_id}.{ext}"
+            filename = f"{config.today}_{etag}_{file_id}.{ext}"
         else:
             filename = f"{config.today}__NaN__{file_id}.{ext}"
         logger.debug("filename=%s", filename)

--- a/src/sciscrape/downloaders.py
+++ b/src/sciscrape/downloaders.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass, field
 from os import path
 from time import sleep
 import re
+from typing import Any
 from requests import Response
 from selectolax.parser import HTMLParser
 
@@ -42,10 +43,10 @@ class DownloadReceipt:
     filepath: str = "N/A"
 
     @classmethod
-    def from_dict(cls, dict_input: dict):
+    def from_dict(cls, dict_input: dict[str, Any]) -> DownloadReceipt:
         return cls(**dict_input)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 

--- a/src/sciscrape/downloaders.py
+++ b/src/sciscrape/downloaders.py
@@ -118,7 +118,7 @@ class Downloader(ABC):
         -------
             A .pdf or .png file, depending on the `Downloader` in use.
         """
-        with (change_dir(self.export_dir), TemporaryFile() as temp):
+        with change_dir(self.export_dir), TemporaryFile() as temp:
             temp.write(contents)
             with open(filename, "wb") as file:
                 for line in temp:

--- a/src/sciscrape/factories.py
+++ b/src/sciscrape/factories.py
@@ -5,6 +5,8 @@ including the Dimensions.ai API and local directories.
 It also includes functions for serializing and staging the scraped data.
 """
 
+from __future__ import annotations
+
 from functools import partial
 from sciscrape.docscraper import DocScraper
 from sciscrape.webscrapers import DimensionsScraper

--- a/src/sciscrape/factories.py
+++ b/src/sciscrape/factories.py
@@ -90,7 +90,7 @@ def read_factory() -> SciScraper:
     """
 
     while True:
-        scrape_process: str = input(
+        scrape_process = input(
             f"Enter desired data scraping process ({', '.join(SCISCRAPERS)}): "
         )
         try:

--- a/src/sciscrape/fetch.py
+++ b/src/sciscrape/fetch.py
@@ -57,7 +57,7 @@ class Fetcher(ABC):
     scraper: DocScraper | WebScraper | Downloader
 
     @abstractmethod
-    def __call__(self, *args, **kwargs) -> pd.DataFrame:
+    def __call__(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
         """The __call__ method in ScrapeFetcher and StagingFetcher
         take a target FilePath or dataframe respectively.
         They are converted them into lists of entries.
@@ -134,7 +134,7 @@ class StagingFetcher(Fetcher):
         return dataframe
 
     def fetch_from_staged_series(
-        self, prior_dataframe: pd.DataFrame, staged_terms: list
+        self, prior_dataframe: pd.DataFrame, staged_terms: list[Any]
     ) -> pd.DataFrame:
         """If the terms are staged as a list, then the dataframe is extended
         along the provided query, and then it is appended to the existing dataframe."""
@@ -227,7 +227,7 @@ class SciScraper:
         return dataframe
 
     @staticmethod
-    def downcast_available_datetimes(dataframe: pd.DataFrame | pd.Series):
+    def downcast_available_datetimes(dataframe: pd.DataFrame | pd.Series) -> pd.Timestamp:
         """Converts all paper publication dates to the datetime format."""
         return pd.to_datetime(dataframe["pub_date"], infer_datetime_format=True)
 

--- a/src/sciscrape/fetch.py
+++ b/src/sciscrape/fetch.py
@@ -4,7 +4,7 @@ returning various dataframes for each"""
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
 from typing import (
-    Generator,
+    Iterator,
     Callable,
     Iterable,
     Any,
@@ -89,7 +89,7 @@ class Fetcher(ABC):
         pd.DataFrame
             A dataframe containing biliographic data.
         """
-        data: Generator[ScrapeResult | None, None, None] = (
+        data: Iterator[ScrapeResult | None] = (
             self.scraper.obtain(term)
             for term in tqdm(search_terms, desc="[sciscraper]: ", unit=f"{tqdm_unit}")
         )

--- a/src/sciscrape/fetch.py
+++ b/src/sciscrape/fetch.py
@@ -156,7 +156,7 @@ class StagingFetcher(Fetcher):
         provide the source titles, from which the ensuing citations
         were originally found. The prior dataframe is not kept."""
         citations, src_titles = staged_terms
-        ref_dataframe: pd.DataFrame = self.fetch(citations, "references")
+        ref_dataframe = self.fetch(citations, "references")
         dataframe = ref_dataframe.join(
             pd.Series(
                 src_titles,
@@ -257,6 +257,6 @@ class SciScraper:
         """Returns a `export_name` for the spreadsheet with
         both today's date and a randomly generated `print_id`
         number."""
-        print_id: int = randint(0, 100)
-        export_name: str = f"{config.today}_sciscraper_{print_id}.csv"
+        print_id = randint(0, 100)
+        export_name = f"{config.today}_sciscraper_{print_id}.csv"
         return export_name

--- a/src/sciscrape/fetch.py
+++ b/src/sciscrape/fetch.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
 from typing import (
     Generator,
-    Optional,
     Callable,
     Iterable,
     Any,
@@ -90,7 +89,7 @@ class Fetcher(ABC):
         pd.DataFrame
             A dataframe containing biliographic data.
         """
-        data: Generator[Optional[ScrapeResult], None, None] = (
+        data: Generator[ScrapeResult | None, None, None] = (
             self.scraper.obtain(term)
             for term in tqdm(search_terms, desc="[sciscraper]: ", unit=f"{tqdm_unit}")
         )
@@ -176,7 +175,7 @@ class SciScraper:
     """
 
     scraper: ScrapeFetcher
-    stager: Optional[StagingFetcher]
+    stager: StagingFetcher | None
     logger = logger
     downcast: bool = True
 

--- a/src/sciscrape/fetch.py
+++ b/src/sciscrape/fetch.py
@@ -1,12 +1,15 @@
 r"""Contains methods that take various files and directories, which each
 returning various dataframes for each"""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
 from typing import (
     Iterator,
     Callable,
     Iterable,
+    Union,
     Any,
 )
 
@@ -21,9 +24,9 @@ from sciscrape.downloaders import Downloader, DownloadReceipt
 from sciscrape.change_dir import change_dir
 from sciscrape.log import logger
 
-SerializationStrategyFunction = Callable[[FilePath], list[str]]
+SerializationStrategyFunction = Callable[[FilePath], "list[str]"]
 StagingStrategyFunction = Callable[[pd.DataFrame], Iterable[Any]]
-ScrapeResult = DocumentResult | WebScrapeResult | DownloadReceipt
+ScrapeResult = Union[DocumentResult, WebScrapeResult, DownloadReceipt]
 
 
 KEY_TYPE_PAIRINGS: dict[str, Any] = {

--- a/src/sciscrape/profilers.py
+++ b/src/sciscrape/profilers.py
@@ -68,7 +68,7 @@ def run_bytecode_profiler(sciscrape: SciScraper) -> None:
     dis.dis(sciscrape.__call__)
 
 
-def get_profiler(args: Namespace, sciscrape: SciScraper):
+def get_profiler(args: Namespace, sciscrape: SciScraper) -> None:
     profiler_dict = {
         "benchmark": partial(run_benchmark, args=args),
         "memory": partial(run_memory_profiler, args=args),

--- a/src/sciscrape/serials.py
+++ b/src/sciscrape/serials.py
@@ -60,7 +60,7 @@ def serialize_from_directory(target: FilePath, suffix: str = "pdf") -> list[str]
         A list of files from the provided directory, `target` that adhere
         to the requested format `suffix`.
     """
-    data_list: list[str] = [
+    data_list = [
         path.join(target, file)
         for file in listdir(target)
         if fnmatch(path.basename(file), f"*.{suffix}")
@@ -73,7 +73,7 @@ def serialize_from_directory(target: FilePath, suffix: str = "pdf") -> list[str]
 
 
 def clean_any_nested_columns(data_list: list[str], column: str) -> list[str]:
-    initial_terms: list[str] = [term for term in data_list if not term.startswith("{")]
+    initial_terms = [term for term in data_list if not term.startswith("{")]
     nested_terms: list[str] = [
         literal_eval(term)[column] for term in data_list if term.startswith("{")
     ]

--- a/src/sciscrape/serials.py
+++ b/src/sciscrape/serials.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fnmatch import fnmatch
 from os import listdir, path
 from ast import literal_eval

--- a/src/sciscrape/stagers.py
+++ b/src/sciscrape/stagers.py
@@ -108,17 +108,17 @@ def stage_with_reference(
     >>> stage_with_reference(df) =
     return (['a','b','c','d','e','f','g'],['apple','apple','apple','orange','orange','banana','banana'])
     """
-    data: pd.DataFrame = (
+    data = (
         target
         .copy()
         .explode(column_x)
     )
-    data_col_x: list[str] = clean_any_nested_columns(
+    data_col_x = clean_any_nested_columns(
         data[column_x].fillna("N/A").to_list(), column_x
     )
-    data_col_y: list[str] = clean_any_nested_columns(
+    data_col_y = clean_any_nested_columns(
         data[column_y].fillna("N/A").to_list(), column_y
     )
-    staged_terms: tuple[list[str], list[str]] = (data_col_x, data_col_y)
+    staged_terms = (data_col_x, data_col_y)
     logger.debug("stager=%s, terms=%s", stage_with_reference, staged_terms)
     return staged_terms

--- a/src/sciscrape/stagers.py
+++ b/src/sciscrape/stagers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 from sciscrape.log import logger
 from sciscrape.serials import clean_any_nested_columns

--- a/src/sciscrape/webscrapers.py
+++ b/src/sciscrape/webscrapers.py
@@ -123,7 +123,7 @@ class DimensionsScraper(WebScraper):
         return client.get(self.url, params=querystring)
 
     def enrich_response(self, response: Response) -> dict[str, Any]:
-        api_keys: dict[str, str] = DIMENSIONS_AI_KEYS
+        api_keys = DIMENSIONS_AI_KEYS
 
         getters: dict[str, tuple[str, WebScraper]] = {
             "biblio": (
@@ -141,7 +141,7 @@ class DimensionsScraper(WebScraper):
         }
 
         item = self.get_items_from_response(response.text, "docs")
-        data: dict[str, Any] = {
+        data = {
             key: item.get(value) for (key, value) in api_keys.items()
         }
         for key, getter in getters.items():
@@ -227,8 +227,8 @@ class CitationScraper(WebScraper):
     lang: str = "en-US"
 
     def obtain(self, search_text: str) -> str | None:
-        querystring: dict[str, Any] = self.create_querystring(search_text)
-        response: Response = client.get(self.url, params=querystring)
+        querystring = self.create_querystring(search_text)
+        response = client.get(self.url, params=querystring)
         logger.debug(
             "search_text=%s, scraper=%r, status_code=%s",
             search_text,
@@ -254,8 +254,8 @@ class OverviewScraper(WebScraper):
     """
 
     def obtain(self, search_text: str) -> str | None:
-        url: str = f"{self.url}/{search_text}/abstract.json"
-        response: Response = client.get(url)
+        url = f"{self.url}/{search_text}/abstract.json"
+        response = client.get(url)
         logger.debug(
             "search_text=%s, scraper=%r, status_code=%s",
             search_text,
@@ -285,7 +285,7 @@ class SemanticFigureScraper(WebScraper):
         paper_url = self.find_paper_url(search_text)
         if paper_url is None:
             return None
-        response: Response = client.get(paper_url)
+        response = client.get(paper_url)
         logger.debug(
             "paper_url=%s, scraper=%r, status_code=%s",
             paper_url,
@@ -298,7 +298,7 @@ class SemanticFigureScraper(WebScraper):
 
     def find_paper_url(self, search_text: str) -> str | None:
         paper_searching_url = self.url + urlencode({"query": search_text, "fields": "url", "limit": 1})
-        paper_searching_response: Response = client.get(paper_searching_url)
+        paper_searching_response = client.get(paper_searching_url)
         paper_info: dict[str, Any] = loads(paper_searching_response.text)
         try:
             paper_url: str | None = paper_info["data"][0]["url"]
@@ -313,6 +313,6 @@ class SemanticFigureScraper(WebScraper):
         return paper_url
 
     def parse_html_tree(self, response_text: str) -> list[Any] | None:
-        tree: HTMLParser = HTMLParser(response_text)
+        tree = HTMLParser(response_text)
         images: list[Any] = tree.css("li.figure-list__figure > a > figure > div > img")
         return [image.attributes.get("src") for image in images] if images else None

--- a/src/sciscrape/webscrapers.py
+++ b/src/sciscrape/webscrapers.py
@@ -48,10 +48,10 @@ class WebScrapeResult:
     abstract: str | None = None
 
     @classmethod
-    def from_dict(cls, dict_input: dict):
+    def from_dict(cls, dict_input: dict[str, Any]) -> WebScrapeResult:
         return cls(**dict_input)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
@@ -118,7 +118,7 @@ class DimensionsScraper(WebScraper):
         data = self.enrich_response(response)
         return WebScrapeResult(**data)
 
-    def get_docs(self, querystring) -> Response:
+    def get_docs(self, querystring: dict[Any, Any]) -> Response:
         sleep(self.sleep_val)
         return client.get(self.url, params=querystring)
 
@@ -237,7 +237,7 @@ class CitationScraper(WebScraper):
         )
         return None if response.status_code != 200 else response.text
 
-    def create_querystring(self, search_text) -> dict[str, Any]:
+    def create_querystring(self, search_text: str) -> dict[str, Any]:
         return {
             "doi": search_text,
             "style": self.style.value,

--- a/src/sciscrape/wordscore.py
+++ b/src/sciscrape/wordscore.py
@@ -96,22 +96,22 @@ class WordscoreCalculator:
             which is calculated as the difference between
             the positive posterior and negative posterior.
         """
-        neutral_part: float = self.total_length - self.target_count
-        success_margin: float = self.get_margin(
+        neutral_part = self.total_length - self.target_count
+        success_margin = self.get_margin(
             self.target_count,
             self.total_length,
         )
-        failure_margin: float = self.get_margin(
+        failure_margin = self.get_margin(
             neutral_part,
             self.total_length,
         )
-        target_probability: float = self.target_count / self.total_length
-        bycatch_probability: float = self.bycatch_count / self.total_length
-        likelihood: float = self.get_likelihood(success_margin, failure_margin)
-        expectation: float = self.target_count * target_probability
-        variance: float = expectation * (1 - target_probability)
-        standard_deviation: float = sqrt(variance)
-        skewness: float = (failure_margin - target_probability) / standard_deviation
+        target_probability = self.target_count / self.total_length
+        bycatch_probability = self.bycatch_count / self.total_length
+        likelihood = self.get_likelihood(success_margin, failure_margin)
+        expectation = self.target_count * target_probability
+        variance = expectation * (1 - target_probability)
+        standard_deviation = sqrt(variance)
+        skewness = (failure_margin - target_probability) / standard_deviation
 
         # Positive posterior is a bayes equation, in which the match likelihood
         # is multiplied by the true positives ratio
@@ -168,7 +168,7 @@ class WordscoreCalculator:
         --------
         >>> P(y|n) = (n! / (y! * (n-y)!) * (y/n)**y * ((n-y)/n)**(n-y))
         """
-        total_combinations: int = comb(
+        total_combinations = comb(
             self.total_length,
             self.target_count,
         )

--- a/src/sciscrape/wordscore.py
+++ b/src/sciscrape/wordscore.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict
 from math import comb, sqrt
+from typing import Any
 
 
 @dataclass(frozen=True, order=True)
@@ -13,10 +14,10 @@ class Wordscore:
     skewness: float
 
     @classmethod
-    def from_dict(cls, dict_input: dict):
+    def from_dict(cls, dict_input: dict[str, Any]) -> Wordscore:
         return cls(**dict_input)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
@@ -232,8 +233,8 @@ class WordscoreCalculator:
         return (part / whole) ** part
 
     @classmethod
-    def from_dict(cls, dict_input: dict):
+    def from_dict(cls, dict_input: dict[str, Any]) -> WordscoreCalculator:
         return cls(**dict_input)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/src/sciscrape/wordscore.py
+++ b/src/sciscrape/wordscore.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, asdict
-from typing import Union
 from math import comb, sqrt
 
 
@@ -205,8 +206,8 @@ class WordscoreCalculator:
 
     def get_margin(
         self,
-        part: Union[int, float],
-        whole: Union[int, float],
+        part: int | float,
+        whole: int | float,
     ) -> float:
         """
         Calculates the margin of an event occurring based on the part divided by the whole,


### PR DESCRIPTION
1. Updated typehints to use pipe union syntax instead of `typing.Optional[T]` or `typing.Union[X, Y]`
2. Removed redundant typehints where the type is clear from context, such as `x: str = "hi"`
3. Converted generator typehints from `Generator[T, None, None]` to `Iterator[T]`
4. Added missing typehints
5. Improved existing typehints (mostly subscripting types)
6. Made typehints backwards compatible with 3.8+
7. Also fixed one syntax error that had a context manager using 3.9+ syntax